### PR TITLE
gpg key params

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -22,6 +22,9 @@ MONGODB_PORT                      MongoDB port number                           
 MONGODB_USER                      MongoDB user to perform the backup
 MONGODB_PASSWORD                  MongoDB user password
 MONGODB_AUTHENTICATION_DATABASE   MongoDB database to authenticate against                                                  admin
+GPG_RECIPIENT                     GPG recpient name to be used to encrypt the database archive
+GPG_PUBLIC_KEY                    GPG public key content (base64 encoded)
+GPG_TRUST_MODEL                   GPG encryption trust model, defaults to "always"
 ```
 
 #### Running the Job
@@ -29,7 +32,7 @@ The job template can be run directly using the Openshift CLI or made available t
 
 ##### OC Command line tool
 ```
-$ oc new-app mongodb-backup-s3-job-template.yaml -p AWS_ACCESS_KEY_ID=<aws_access_key_id> -p AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> -p AWS_S3_BUCKET_NAME=<bucket_name> -p MONGODB_USER=admin -p MONGODB_PASSWORD=<mongodb_admin_password> -p MONGODB_HOST=<mongodb-host> -p MONGODB_AUTHENTICATION_DATABASE=admin
+$ oc new-app mongodb-backup-s3-job-template.yaml -p AWS_ACCESS_KEY_ID=<aws_access_key_id> -p AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> -p AWS_S3_BUCKET_NAME=<bucket_name> -p MONGODB_USER=admin -p MONGODB_PASSWORD=<mongodb_admin_password> -p MONGODB_HOST=<mongodb-host> -p MONGODB_AUTHENTICATION_DATABASE=admin -p GPG_RECIPIENT=admin@admin.com -p "GPG_PUBLIC_KEY=$(cat keys_public.gpg | base64)"
 ```
 
 ###### Validation

--- a/mongodb/mongodb-backup-s3-cronjob-template.yaml
+++ b/mongodb/mongodb-backup-s3-cronjob-template.yaml
@@ -13,7 +13,6 @@ objects:
       name: mongodb-backup-s3-secret
     data:
       gpg_public_key: ${GPG_PUBLIC_KEY}
-      gpg_secret_key: ${GPG_SECRET_KEY}
   - apiVersion: batch/v2alpha1
     kind: CronJob
     metadata:

--- a/mongodb/mongodb-backup-s3-cronjob-template.yaml
+++ b/mongodb/mongodb-backup-s3-cronjob-template.yaml
@@ -42,10 +42,6 @@ objects:
                       value: ${AWS_SECRET_ACCESS_KEY}
                     - name: GPG_RECIPIENT
                       value: ${GPG_RECIPIENT}
-                    - name: GPG_PUBLIC_KEY
-                      value: ${GPG_PUBLIC_KEY}
-                    - name: GPG_SECRET_KEY
-                      value: ${GPG_SECRET_KEY}
                     - name: GPG_TRUST_MODEL
                       value: ${GPG_TRUST_MODEL}
               volumes:

--- a/mongodb/mongodb-backup-s3-cronjob-template.yaml
+++ b/mongodb/mongodb-backup-s3-cronjob-template.yaml
@@ -6,6 +6,14 @@ metadata:
   annotations:
     description: 'Cron job for backing up MongoDB data to Amazon S3'
 objects:
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: mongodb-backup-s3-secret
+    data:
+      gpg_public_key: ${GPG_PUBLIC_KEY}
+      gpg_secret_key: ${GPG_SECRET_KEY}
   - apiVersion: batch/v2alpha1
     kind: CronJob
     metadata:
@@ -24,12 +32,27 @@ objects:
                   command:
                     - 'bash'
                     - '-c'
-                    - '/opt/rh/scripts/mongodb/backup-s3.sh ${MONGODB_HOST} ${MONGODB_PORT} ${MONGODB_USER} ${MONGODB_PASSWORD} ${MONGODB_AUTHENTICATION_DATABASE} ${AWS_S3_BUCKET_NAME}'
+                    - '/opt/rh/scripts/mongodb/backup-s3.sh ${MONGODB_HOST} ${MONGODB_PORT} ${MONGODB_USER} ${MONGODB_PASSWORD} ${MONGODB_AUTHENTICATION_DATABASE} ${AWS_S3_BUCKET_NAME} ${GPG_RECIPIENT}'
+                  volumeMounts:
+                    - name: mongodb-backup-s3-secret-volume
+                      mountPath: /opt/rh/secrets
                   env:
                     - name: AWS_ACCESS_KEY_ID
                       value: ${AWS_ACCESS_KEY_ID}
                     - name: AWS_SECRET_ACCESS_KEY
                       value: ${AWS_SECRET_ACCESS_KEY}
+                    - name: GPG_RECIPIENT
+                      value: ${GPG_RECIPIENT}
+                    - name: GPG_PUBLIC_KEY
+                      value: ${GPG_PUBLIC_KEY}
+                    - name: GPG_SECRET_KEY
+                      value: ${GPG_SECRET_KEY}
+                    - name: GPG_TRUST_MODEL
+                      value: ${GPG_TRUST_MODEL}
+              volumes:
+                - name: mongodb-backup-s3-secret-volume
+                  secret:
+                    secretName: mongodb-backup-s3-secret
               restartPolicy: Never
 parameters:
   - name: AWS_ACCESS_KEY_ID
@@ -59,3 +82,12 @@ parameters:
   - name: MONGODB_AUTHENTICATION_DATABASE
     description: 'MongoDB database to authenticate against'
     value: 'admin'
+  - name: GPG_RECIPIENT
+    description: 'GPG recpient name to be used to encrypt the database archive'
+    required: true
+  - name: GPG_PUBLIC_KEY
+    description: 'GPG public key content (base64 encoded)'
+    required: true
+  - name: GPG_TRUST_MODEL
+    description: 'GPG encryption trust model, defaults to "always"'
+    value: 'always'

--- a/mongodb/mongodb-backup-s3-job-template.yaml
+++ b/mongodb/mongodb-backup-s3-job-template.yaml
@@ -42,10 +42,6 @@ objects:
                   value: ${AWS_SECRET_ACCESS_KEY}
                 - name: GPG_RECIPIENT
                   value: ${GPG_RECIPIENT}
-                - name: GPG_PUBLIC_KEY
-                  value: ${GPG_PUBLIC_KEY}
-                - name: GPG_SECRET_KEY
-                  value: ${GPG_SECRET_KEY}
                 - name: GPG_TRUST_MODEL
                   value: ${GPG_TRUST_MODEL}
           volumes:

--- a/mongodb/mongodb-backup-s3-job-template.yaml
+++ b/mongodb/mongodb-backup-s3-job-template.yaml
@@ -10,10 +10,9 @@ objects:
     apiVersion: v1
     kind: Secret
     metadata:
-      name: rhmap-backup-secret
+      name: mongodb-backup-s3-secret
     data:
       gpg_public_key: ${GPG_PUBLIC_KEY}
-      gpg_secret_key: ${GPG_SECRET_KEY}
   - apiVersion: batch/v1
     kind: Job
     metadata:
@@ -27,13 +26,13 @@ objects:
         spec:
           containers:
             - name: mongodb-backup-s3
-              image: 'rhmap/backups:dev'
+              image: 'docker.io/rhmap/backups:latest'
               command:
                 - 'bash'
                 - '-c'
                 - '/opt/rh/scripts/mongodb/backup-s3.sh ${MONGODB_HOST} ${MONGODB_PORT} ${MONGODB_USER} ${MONGODB_PASSWORD} ${MONGODB_AUTHENTICATION_DATABASE} ${AWS_S3_BUCKET_NAME} ${GPG_RECIPIENT}'
               volumeMounts:
-                - name: rhmap-backup-secret-volume
+                - name: mongodb-backup-s3-secret-volume
                   mountPath: /opt/rh/secrets
                   readOnly: true
               env:
@@ -50,9 +49,9 @@ objects:
                 - name: GPG_TRUST_MODEL
                   value: ${GPG_TRUST_MODEL}
           volumes:
-            - name: rhmap-backup-secret-volume
+            - name: mongodb-backup-s3-secret-volume
               secret:
-                secretName: rhmap-backup-secret
+                secretName: mongodb-backup-s3-secret
           restartPolicy: Never
 parameters:
   - name: AWS_ACCESS_KEY_ID
@@ -84,9 +83,6 @@ parameters:
     required: true
   - name: GPG_PUBLIC_KEY
     description: 'GPG public key content (base64 encoded)'
-    required: true
-  - name: GPG_SECRET_KEY
-    description: 'GPG secret key content (base64 encoded)'
     required: true
   - name: GPG_TRUST_MODEL
     description: 'GPG encryption trust model, defaults to "always"'

--- a/mongodb/mongodb-backup-s3-job-template.yaml
+++ b/mongodb/mongodb-backup-s3-job-template.yaml
@@ -6,6 +6,14 @@ metadata:
   annotations:
     description: 'Job for backing up MongoDB data to Amazon S3'
 objects:
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: rhmap-backup-secret
+    data:
+      gpg_public_key: ${GPG_PUBLIC_KEY}
+      gpg_secret_key: ${GPG_SECRET_KEY}
   - apiVersion: batch/v1
     kind: Job
     metadata:
@@ -19,16 +27,32 @@ objects:
         spec:
           containers:
             - name: mongodb-backup-s3
-              image: 'docker.io/rhmap/backups:latest'
+              image: 'rhmap/backups:dev'
               command:
                 - 'bash'
                 - '-c'
-                - '/opt/rh/scripts/mongodb/backup-s3.sh ${MONGODB_HOST} ${MONGODB_PORT} ${MONGODB_USER} ${MONGODB_PASSWORD} ${MONGODB_AUTHENTICATION_DATABASE} ${AWS_S3_BUCKET_NAME}'
+                - '/opt/rh/scripts/mongodb/backup-s3.sh ${MONGODB_HOST} ${MONGODB_PORT} ${MONGODB_USER} ${MONGODB_PASSWORD} ${MONGODB_AUTHENTICATION_DATABASE} ${AWS_S3_BUCKET_NAME} ${GPG_RECIPIENT}'
+              volumeMounts:
+                - name: rhmap-backup-secret-volume
+                  mountPath: /opt/rh/secrets
+                  readOnly: true
               env:
                 - name: AWS_ACCESS_KEY_ID
                   value: ${AWS_ACCESS_KEY_ID}
                 - name: AWS_SECRET_ACCESS_KEY
                   value: ${AWS_SECRET_ACCESS_KEY}
+                - name: GPG_RECIPIENT
+                  value: ${GPG_RECIPIENT}
+                - name: GPG_PUBLIC_KEY
+                  value: ${GPG_PUBLIC_KEY}
+                - name: GPG_SECRET_KEY
+                  value: ${GPG_SECRET_KEY}
+                - name: GPG_TRUST_MODEL
+                  value: ${GPG_TRUST_MODEL}
+          volumes:
+            - name: rhmap-backup-secret-volume
+              secret:
+                secretName: rhmap-backup-secret
           restartPolicy: Never
 parameters:
   - name: AWS_ACCESS_KEY_ID
@@ -55,3 +79,15 @@ parameters:
   - name: MONGODB_AUTHENTICATION_DATABASE
     description: 'MongoDB database to authenticate against'
     value: 'admin'
+  - name: GPG_RECIPIENT
+    description: 'GPG recpient name to be used to encrypt the database archive'
+    required: true
+  - name: GPG_PUBLIC_KEY
+    description: 'GPG public key content (base64 encoded)'
+    required: true
+  - name: GPG_SECRET_KEY
+    description: 'GPG secret key content (base64 encoded)'
+    required: true
+  - name: GPG_TRUST_MODEL
+    description: 'GPG encryption trust model, defaults to "always"'
+    value: 'always'

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -20,6 +20,9 @@ AWS_S3_BUCKET_NAME      Name of an existing Amazon S3 bucket where backups are t
 MYSQL_HOST              MySQL host to target
 MYSQL_USER              MySQL user to perform the backup
 MYSQL_PASSWORD          MySQL user password
+GPG_RECIPIENT                     GPG recpient name to be used to encrypt the database archive
+GPG_PUBLIC_KEY                    GPG public key content (base64 encoded)
+GPG_TRUST_MODEL                   GPG encryption trust model, defaults to "always"
 ```
 
 #### Running the Job
@@ -27,7 +30,7 @@ The job template can be run directly using the Openshift CLI or made available t
 
 ##### OC Command line tool
 ```
-$ oc new-app mysql-backup-s3-job-template.yaml -p AWS_ACCESS_KEY_ID=<aws_access_key_id> -p AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> -p AWS_S3_BUCKET_NAME=<bucket_name> -p MYSQL_USER=<mysql-user> -p MYSQL_PASSWORD=<mysql_admin_password> -p MYSQL_HOST=<mysql-host>
+$ oc new-app mysql-backup-s3-job-template.yaml -p AWS_ACCESS_KEY_ID=<aws_access_key_id> -p AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> -p AWS_S3_BUCKET_NAME=<bucket_name> -p MYSQL_USER=<mysql-user> -p MYSQL_PASSWORD=<mysql_admin_password> -p MYSQL_HOST=<mysql-host> -p GPG_RECIPIENT=admin@admin.com -p "GPG_PUBLIC_KEY=$(cat keys_public.gpg | base64)"
 ```
 
 ###### Validation

--- a/mysql/mysql-backup-s3-cronjob-template.yaml
+++ b/mysql/mysql-backup-s3-cronjob-template.yaml
@@ -43,10 +43,6 @@ objects:
                       value: ${AWS_SECRET_ACCESS_KEY}
                     - name: GPG_RECIPIENT
                       value: ${GPG_RECIPIENT}
-                    - name: GPG_PUBLIC_KEY
-                      value: ${GPG_PUBLIC_KEY}
-                    - name: GPG_SECRET_KEY
-                      value: ${GPG_SECRET_KEY}
                     - name: GPG_TRUST_MODEL
                       value: ${GPG_TRUST_MODEL}
               volumes:

--- a/mysql/mysql-backup-s3-cronjob-template.yaml
+++ b/mysql/mysql-backup-s3-cronjob-template.yaml
@@ -24,12 +24,28 @@ objects:
                   command:
                     - 'bash'
                     - '-c'
-                    - '/opt/rh/scripts/mysql/backup-s3.sh ${MYSQL_HOST} ${MYSQL_USER} ${MYSQL_PASSWORD} ${AWS_S3_BUCKET_NAME}'
+                    - '/opt/rh/scripts/mysql/backup-s3.sh ${MYSQL_HOST} ${MYSQL_USER} ${MYSQL_PASSWORD} ${AWS_S3_BUCKET_NAME} ${GPG_RECIPIENT}'
+                  volumeMounts:
+                    - name: mysql-backup-s3-secret-volume
+                      mountPath: /opt/rh/secrets
+                      readOnly: true
                   env:
                     - name: AWS_ACCESS_KEY_ID
                       value: ${AWS_ACCESS_KEY_ID}
                     - name: AWS_SECRET_ACCESS_KEY
                       value: ${AWS_SECRET_ACCESS_KEY}
+                    - name: GPG_RECIPIENT
+                      value: ${GPG_RECIPIENT}
+                    - name: GPG_PUBLIC_KEY
+                      value: ${GPG_PUBLIC_KEY}
+                    - name: GPG_SECRET_KEY
+                      value: ${GPG_SECRET_KEY}
+                    - name: GPG_TRUST_MODEL
+                      value: ${GPG_TRUST_MODEL}
+              volumes:
+                - name: mysql-backup-s3-secret-volume
+                secret:
+                  secretName: mysql-backup-s3-secret
               restartPolicy: Never
 parameters:
   - name: AWS_ACCESS_KEY_ID
@@ -53,3 +69,12 @@ parameters:
   - name: MYSQL_PASSWORD
     description: 'MySQL user password'
     required: true
+  - name: GPG_RECIPIENT
+    description: 'GPG recpient name to be used to encrypt the database archive'
+    required: true
+  - name: GPG_PUBLIC_KEY
+    description: 'GPG public key content (base64 encoded)'
+    required: true
+  - name: GPG_TRUST_MODEL
+    description: 'GPG encryption trust model, defaults to "always"'
+    value: 'always'

--- a/mysql/mysql-backup-s3-cronjob-template.yaml
+++ b/mysql/mysql-backup-s3-cronjob-template.yaml
@@ -6,6 +6,13 @@ metadata:
   annotations:
     description: 'Cron job for backing up MySQL data to Amazon S3'
 objects:
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: mysql-backup-s3-secret
+    data:
+      gpg_public_key: ${GPG_PUBLIC_KEY}
   - apiVersion: batch/v2alpha1
     kind: CronJob
     metadata:

--- a/mysql/mysql-backup-s3-job-template.yaml
+++ b/mysql/mysql-backup-s3-job-template.yaml
@@ -42,10 +42,6 @@ objects:
                   value: ${AWS_SECRET_ACCESS_KEY}
                 - name: GPG_RECIPIENT
                   value: ${GPG_RECIPIENT}
-                - name: GPG_PUBLIC_KEY
-                  value: ${GPG_PUBLIC_KEY}
-                - name: GPG_SECRET_KEY
-                  value: ${GPG_SECRET_KEY}
                 - name: GPG_TRUST_MODEL
                   value: ${GPG_TRUST_MODEL}
           volumes:

--- a/mysql/mysql-backup-s3-job-template.yaml
+++ b/mysql/mysql-backup-s3-job-template.yaml
@@ -23,12 +23,28 @@ objects:
               command:
                 - 'bash'
                 - '-c'
-                - '/opt/rh/scripts/mysql/backup-s3.sh ${MYSQL_HOST} ${MYSQL_USER} ${MYSQL_PASSWORD} ${AWS_S3_BUCKET_NAME}'
+                - '/opt/rh/scripts/mysql/backup-s3.sh ${MYSQL_HOST} ${MYSQL_USER} ${MYSQL_PASSWORD} ${AWS_S3_BUCKET_NAME} ${GPG_RECIPIENT}'
+              volumeMounts:
+                - name: mysql-backup-s3-secret-volume
+                  mountPath: /opt/rh/secrets
+                  readOnly: true
               env:
                 - name: AWS_ACCESS_KEY_ID
                   value: ${AWS_ACCESS_KEY_ID}
                 - name: AWS_SECRET_ACCESS_KEY
                   value: ${AWS_SECRET_ACCESS_KEY}
+                - name: GPG_RECIPIENT
+                  value: ${GPG_RECIPIENT}
+                - name: GPG_PUBLIC_KEY
+                  value: ${GPG_PUBLIC_KEY}
+                - name: GPG_SECRET_KEY
+                  value: ${GPG_SECRET_KEY}
+                - name: GPG_TRUST_MODEL
+                  value: ${GPG_TRUST_MODEL}
+          volumes:
+            - name: mysql-backup-s3-secret-volume
+              secret:
+                secretName: mysql-backup-s3-secret
           restartPolicy: Never
 parameters:
   - name: AWS_ACCESS_KEY_ID
@@ -49,3 +65,12 @@ parameters:
   - name: MYSQL_PASSWORD
     description: 'MySQL user password'
     required: true
+  - name: GPG_RECIPIENT
+    description: 'GPG recpient name to be used to encrypt the database archive'
+    required: true
+  - name: GPG_PUBLIC_KEY
+    description: 'GPG public key content (base64 encoded)'
+    required: true
+  - name: GPG_TRUST_MODEL
+    description: 'GPG encryption trust model, defaults to "always"'
+    value: 'always'

--- a/mysql/mysql-backup-s3-job-template.yaml
+++ b/mysql/mysql-backup-s3-job-template.yaml
@@ -6,6 +6,13 @@ metadata:
   annotations:
     description: 'Job for backing up MySQL data to Amazon S3'
 objects:
+  -
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: mysql-backup-s3-secret
+    data:
+      gpg_public_key: ${GPG_PUBLIC_KEY}
   - apiVersion: batch/v1
     kind: Job
     metadata:

--- a/scripts/mongodb/backup-s3.sh
+++ b/scripts/mongodb/backup-s3.sh
@@ -8,17 +8,23 @@ USER=$3
 PASSWORD=$4
 AUTH_DB=$5
 S3_BUCKET_NAME=$6
+GPG_RECIPIENT=$7
 
 DATESTAMP=$(date '+%Y-%m-%d')
 
 # Retrieve a list of all databases
 DATABASES=$(mongo $HOST:$PORT/admin -u $USER -p $PASSWORD --eval  "printjson(db.adminCommand('listDatabases'))" | grep name | cut -d '"' -f4 | grep -v local)
 
+if [[ ! -z $GPG_RECIPIENT ]]; then
+  gpg --import /opt/rh/secrets/gpg_public_key
+  gpg --import /opt/rh/secrets/gpg_secret_key
+fi
+
 # For each database archive data and push directly to S3
 for DATABASE in $DATABASES; do
   TIMESTAMP=$(date '+%H:%M:%S')
-  echo "==> Dumping database $DATABASE to S3 bucket s3://$S3_BUCKET_NAME/backups/mysql/$DATESTAMP/"
-  mongodump -h $HOST:$PORT -u $USER -p $PASSWORD -d $DATABASE --archive --gzip --authenticationDatabase $AUTH_DB | aws s3 cp - s3://$S3_BUCKET_NAME/backups/mongodb/$DATESTAMP/$DATABASE-$TIMESTAMP.dump.gz
+  echo "==> Dumping database $DATABASE to S3 bucket s3://$S3_BUCKET_NAME/backups/mongodb/$DATESTAMP/"
+  mongodump -h $HOST:$PORT -u $USER -p $PASSWORD -d $DATABASE --archive --gzip --authenticationDatabase $AUTH_DB | gpg --encrypt --recipient "$GPG_RECIPIENT" --trust-model $GPG_TRUST_MODEL | aws s3 cp - s3://$S3_BUCKET_NAME/backups/mongodb/$DATESTAMP/$DATABASE-$TIMESTAMP.dump.gz
   STATUS=$?
   if [ $STATUS -eq 0 ]; then
     echo "==> Dump $DATABASE: COMPLETED"

--- a/scripts/mongodb/backup-s3.sh
+++ b/scripts/mongodb/backup-s3.sh
@@ -15,10 +15,8 @@ DATESTAMP=$(date '+%Y-%m-%d')
 # Retrieve a list of all databases
 DATABASES=$(mongo $HOST:$PORT/admin -u $USER -p $PASSWORD --eval  "printjson(db.adminCommand('listDatabases'))" | grep name | cut -d '"' -f4 | grep -v local)
 
-if [[ ! -z $GPG_RECIPIENT ]]; then
-  gpg --import /opt/rh/secrets/gpg_public_key
-  gpg --import /opt/rh/secrets/gpg_secret_key
-fi
+# Imports the gpg public key
+gpg --import /opt/rh/secrets/gpg_public_key
 
 # For each database archive data and push directly to S3
 for DATABASE in $DATABASES; do


### PR DESCRIPTION
Sending for early feedback, sample usage:

``` 
oc new-app -f mongodb/mongodb-backup-s3-job-template.yaml \
-p AWS_ACCESS_KEY_ID=mykey \
-p AWS_SECRET_ACCESS_KEY=meysecret \
-p AWS_S3_BUCKET_NAME=mybucket \
-p MONGODB_USER=admin \
-p MONGODB_PASSWORD=admin \
-p MONGODB_HOST=mongodb \
-p GPG_RECIPIENT=admin@admin.com \
-p "GPG_PUBLIC_KEY=$(cat public_key.gpg | base64)" \
-p "GPG_SECRET_KEY=$(cat secret_key.gpg | base64)"
```

GPG usage will be mandatory in this case,  do we need to make it optional? If that's the case I will create a separate template for gpg usage and adapt the backup script as needed.
