### PR TITLE
Minor correction to job name to be consistent with published template

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -50,7 +50,7 @@ Dumping database mydatabase to S3 bucket my-s3-bucket...
 
 ###### Remove the Job
 ```
-$ oc delete job mongodb-backup-s3-job
+$ oc delete job mongodb-backup-s3
 ```
 
 ##### Service Catalog


### PR DESCRIPTION
@pmccarthy The previous job name listed in this doc is inconsistent with the job name found in the template. This resulted in this:

```
[root@rhm-eng-a-master-03f3e ~]# oc delete job mongodb-backup-s3-job
Error from server (NotFound): jobs.batch "mongodb-backup-s3-job" not found
```

I have rectified, which now results in:

```
[root@rhm-eng-a-master-03f3e ~]# oc delete job mongodb-backup-s3
job "mongodb-backup-s3" deleted
```

This change is just to document that.

Please review and approve.