### PR TITLE
Minor correction to job name in template to be consistent with publis…

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -53,6 +53,12 @@ Dumping database mydatabase to S3 bucket my-s3-bucket...
 $ oc delete job mongodb-backup-s3-job
 ```
 
+###### Remove the Secret
+There is a secret bound to a job when it is initiated. Therefore, when the job to removed, the secret must also be removed to maintain consistency.
+```
+oc delete secret mongodb-backup-s3-secret
+```
+
 ##### Service Catalog
 ###### Create Template and make available through the Service Catalog
 Specify the project where you want the job to run from:

--- a/mongodb/mongodb-backup-s3-job-template.yaml
+++ b/mongodb/mongodb-backup-s3-job-template.yaml
@@ -16,16 +16,16 @@ objects:
   - apiVersion: batch/v1
     kind: Job
     metadata:
-      name: mongodb-backup-s3
+      name: mongodb-backup-s3-job
     spec:
       parallelism: 1
       completions: 1
       template:
         metadata:
-          name: mongodb-backup-s3
+          name: mongodb-backup-s3-job
         spec:
           containers:
-            - name: mongodb-backup-s3
+            - name: mongodb-backup-s3-job
               image: 'docker.io/rhmap/backups:latest'
               command:
                 - 'bash'


### PR DESCRIPTION
…hed docs

@pmccarthy The previous job name listed in this doc is inconsistent with the job name found in the template. This resulted in this:

```
[root@rhm-eng-a-master-03f3e ~]# oc delete job mongodb-backup-s3-job
Error from server (NotFound): jobs.batch "mongodb-backup-s3-job" not found
```

I have rectified by changing the template to reflect the docs.

I have tested successfully on one of our test clusters.

Please review and approve.