### PR TITLE
Adding imagePullPolicy to always pull down latest

### DIFF
--- a/mongodb/mongodb-backup-s3-cronjob-template.yaml
+++ b/mongodb/mongodb-backup-s3-cronjob-template.yaml
@@ -28,6 +28,7 @@ objects:
               containers:
                 - name: mongodb-backup-s3-cronjob
                   image: 'docker.io/rhmap/backups:latest'
+                  imagePullPolicy: Always
                   command:
                     - 'bash'
                     - '-c'

--- a/mongodb/mongodb-backup-s3-job-template.yaml
+++ b/mongodb/mongodb-backup-s3-job-template.yaml
@@ -27,6 +27,7 @@ objects:
           containers:
             - name: mongodb-backup-s3-job
               image: 'docker.io/rhmap/backups:latest'
+              imagePullPolicy: Always
               command:
                 - 'bash'
                 - '-c'

--- a/mysql/mysql-backup-s3-cronjob-template.yaml
+++ b/mysql/mysql-backup-s3-cronjob-template.yaml
@@ -28,6 +28,7 @@ objects:
               containers:
                 - name: mysql-backup-s3-cronjob
                   image: 'docker.io/rhmap/backups:latest'
+                  imagePullPolicy: Always
                   command:
                     - 'bash'
                     - '-c'

--- a/mysql/mysql-backup-s3-job-template.yaml
+++ b/mysql/mysql-backup-s3-job-template.yaml
@@ -27,6 +27,7 @@ objects:
           containers:
             - name: mysql-backup-s3
               image: 'docker.io/rhmap/backups:latest'
+              imagePullPolicy: Always
               command:
                 - 'bash'
                 - '-c'


### PR DESCRIPTION
**Summary**
To ensure that all 4x hosted clusters get the latest version of the rhmap-backup image automatically, we need to set an ```imagePullPolicy: Always``` in our job templates. This avoids the Mobile NOC having to push the backup image to every cluster should something change in the image itself.