### PR TITLE
Adding support for MongoDB replica sets

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -14,16 +14,18 @@ The job template requires a number of parameters to be specified. These can be v
 ```
 $ oc process --parameters -f mongodb-backup-s3-job-template.yaml
 NAME                              DESCRIPTION                                                           GENERATOR           VALUE
-AWS_ACCESS_KEY_ID                 AWS Access Key ID                                                                         
-AWS_SECRET_ACCESS_KEY             AWS Secret Access Key                                                                     
-AWS_S3_BUCKET_NAME                Name of an existing Amazon S3 bucket where backups are to be pushed                       
-MONGODB_HOST                      MongoDB host to target                                                                    
+AWS_ACCESS_KEY_ID                 AWS Access Key ID
+AWS_SECRET_ACCESS_KEY             AWS Secret Access Key
+AWS_S3_BUCKET_NAME                Name of an existing Amazon S3 bucket where backups are to be pushed
+BACKUP_IMAGE                      Backup docker image URL                                                                   docker.io/rhmap/backups
+BACKUP_IMAGE_TAG                  Backup docker image tag                                                                   latest
+MONGODB_HOST                      MongoDB host to target
 MONGODB_PORT                      MongoDB port number                                                                       27017
-MONGODB_USER                      MongoDB user to perform the backup                                                        
-MONGODB_PASSWORD                  MongoDB user password                                                                     
+MONGODB_USER                      MongoDB user to perform the backup
+MONGODB_PASSWORD                  MongoDB user password
 MONGODB_AUTHENTICATION_DATABASE   MongoDB database to authenticate against                                                  admin
-GPG_RECIPIENT                     GPG recpient name to be used to encrypt the database archive                              
-GPG_PUBLIC_KEY                    GPG public key content (base64 encoded)                                                   
+GPG_RECIPIENT                     GPG recpient name to be used to encrypt the database archive
+GPG_PUBLIC_KEY                    GPG public key content (base64 encoded)
 GPG_TRUST_MODEL                   GPG encryption trust model, defaults to "always"                                          always
 ```
 
@@ -87,17 +89,19 @@ The cronjob template requires a number of parameters to be specified. These can 
 ```
 $ oc process --parameters -f mongodb-backup-s3-cronjob-template.yaml
 NAME                              DESCRIPTION                                                           GENERATOR           VALUE
-AWS_ACCESS_KEY_ID                 AWS Access Key ID                                                                         
-AWS_SECRET_ACCESS_KEY             AWS Secret Access Key                                                                     
-AWS_S3_BUCKET_NAME                Name of an existing Amazon S3 bucket where backups are to be pushed                       
+AWS_ACCESS_KEY_ID                 AWS Access Key ID
+AWS_SECRET_ACCESS_KEY             AWS Secret Access Key
+AWS_S3_BUCKET_NAME                Name of an existing Amazon S3 bucket where backups are to be pushed
 CRON_SCHEDULE                     Job schedule in Cron Format [Default is everyday at 2am]                                  0 2 * * *
-MONGODB_HOST                      MongoDB host to target                                                                    
+BACKUP_IMAGE                      Backup docker image URL                                                                   docker.io/rhmap/backups
+BACKUP_IMAGE_TAG                  Backup docker image tag                                                                   latest
+MONGODB_HOST                      MongoDB host to target
 MONGODB_PORT                      MongoDB port number                                                                       27017
-MONGODB_USER                      MongoDB user to perform the backup                                                        
-MONGODB_PASSWORD                  MongoDB user password                                                                     
+MONGODB_USER                      MongoDB user to perform the backup
+MONGODB_PASSWORD                  MongoDB user password
 MONGODB_AUTHENTICATION_DATABASE   MongoDB database to authenticate against                                                  admin
-GPG_RECIPIENT                     GPG recpient name to be used to encrypt the database archive                              
-GPG_PUBLIC_KEY                    GPG public key content (base64 encoded)                                                   
+GPG_RECIPIENT                     GPG recpient name to be used to encrypt the database archive
+GPG_PUBLIC_KEY                    GPG public key content (base64 encoded)
 GPG_TRUST_MODEL                   GPG encryption trust model, defaults to "always"                                          always
 ```
 

--- a/mongodb/mongodb-backup-s3-cronjob-template.yaml
+++ b/mongodb/mongodb-backup-s3-cronjob-template.yaml
@@ -27,7 +27,7 @@ objects:
             spec:
               containers:
                 - name: mongodb-backup-s3-cronjob
-                  image: 'docker.io/rhmap/backups:latest'
+                  image: "${BACKUP_IMAGE}:${BACKUP_IMAGE_TAG}"
                   imagePullPolicy: Always
                   command:
                     - 'bash'
@@ -63,6 +63,12 @@ parameters:
   - name: CRON_SCHEDULE
     description: 'Job schedule in Cron Format [Default is everyday at 2am]'
     value: '0 2 * * *'
+  - name: BACKUP_IMAGE
+    description: 'Backup docker image URL'
+    value: 'docker.io/rhmap/backups'
+  - name: BACKUP_IMAGE_TAG
+    description: 'Backup docker image tag'
+    value: 'latest'
   - name: MONGODB_HOST
     description: 'MongoDB host to target'
     required: true

--- a/mongodb/mongodb-backup-s3-job-template.yaml
+++ b/mongodb/mongodb-backup-s3-job-template.yaml
@@ -26,7 +26,7 @@ objects:
         spec:
           containers:
             - name: mongodb-backup-s3-job
-              image: 'docker.io/rhmap/backups:latest'
+              image: 'docker.io/rhmap/backups:1.0.0-38f3766'
               imagePullPolicy: Always
               command:
                 - 'bash'

--- a/mongodb/mongodb-backup-s3-job-template.yaml
+++ b/mongodb/mongodb-backup-s3-job-template.yaml
@@ -26,7 +26,7 @@ objects:
         spec:
           containers:
             - name: mongodb-backup-s3-job
-              image: 'docker.io/rhmap/backups:1.0.0-38f3766'
+              image: "${BACKUP_IMAGE}:${BACKUP_IMAGE_TAG}"
               imagePullPolicy: Always
               command:
                 - 'bash'
@@ -60,6 +60,12 @@ parameters:
   - name: AWS_S3_BUCKET_NAME
     description: 'Name of an existing Amazon S3 bucket where backups are to be pushed'
     required: true
+  - name: BACKUP_IMAGE
+    description: 'Backup docker image URL'
+    value: 'docker.io/rhmap/backups'
+  - name: BACKUP_IMAGE_TAG
+    description: 'Backup docker image tag'
+    value: 'latest'
   - name: MONGODB_HOST
     description: 'MongoDB host to target'
     required: true

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -14,14 +14,16 @@ The job template requires a number of parameters to be specified. These can be v
 ```
 $ oc process --parameters -f mysql-backup-s3-job-template.yaml
 NAME                    DESCRIPTION                                                           GENERATOR           VALUE
-AWS_ACCESS_KEY_ID       AWS Access Key ID                                                                         
-AWS_SECRET_ACCESS_KEY   AWS Secret Access Key                                                                     
-AWS_S3_BUCKET_NAME      Name of an existing Amazon S3 bucket where backups are to be pushed                       
-MYSQL_HOST              MySQL host to target                                                                      
-MYSQL_USER              MySQL user to perform the backup                                                          
-MYSQL_PASSWORD          MySQL user password                                                                       
-GPG_RECIPIENT           GPG recpient name to be used to encrypt the database archive                              
-GPG_PUBLIC_KEY          GPG public key content (base64 encoded)                                                   
+AWS_ACCESS_KEY_ID       AWS Access Key ID
+AWS_SECRET_ACCESS_KEY   AWS Secret Access Key
+AWS_S3_BUCKET_NAME      Name of an existing Amazon S3 bucket where backups are to be pushed
+BACKUP_IMAGE            Backup docker image URL                                                                   docker.io/rhmap/backups
+BACKUP_IMAGE_TAG        Backup docker image tag                                                                   latest
+MYSQL_HOST              MySQL host to target
+MYSQL_USER              MySQL user to perform the backup
+MYSQL_PASSWORD          MySQL user password
+GPG_RECIPIENT           GPG recpient name to be used to encrypt the database archive
+GPG_PUBLIC_KEY          GPG public key content (base64 encoded)
 GPG_TRUST_MODEL         GPG encryption trust model, defaults to "always"                                          always
 ```
 
@@ -77,15 +79,17 @@ The cronjob template requires a number of parameters to be specified. These can 
 ```
 $ oc process --parameters -f mysql-backup-s3-cronjob-template.yaml
 NAME                    DESCRIPTION                                                           GENERATOR           VALUE
-AWS_ACCESS_KEY_ID       AWS Access Key ID                                                                         
-AWS_SECRET_ACCESS_KEY   AWS Secret Access Key                                                                     
-AWS_S3_BUCKET_NAME      Name of an existing Amazon S3 bucket where backups are to be pushed                       
+AWS_ACCESS_KEY_ID       AWS Access Key ID
+AWS_SECRET_ACCESS_KEY   AWS Secret Access Key
+AWS_S3_BUCKET_NAME      Name of an existing Amazon S3 bucket where backups are to be pushed
 CRON_SCHEDULE           Job schedule in Cron Format [Default is everyday at 2am]                                  0 2 * * *
-MYSQL_HOST              MySQL host to target                                                                      
-MYSQL_USER              MySQL user to perform the backup                                                          
-MYSQL_PASSWORD          MySQL user password                                                                       
-GPG_RECIPIENT           GPG recpient name to be used to encrypt the database archive                              
-GPG_PUBLIC_KEY          GPG public key content (base64 encoded)                                                   
+BACKUP_IMAGE            Backup docker image URL                                                                   docker.io/rhmap/backups
+BACKUP_IMAGE_TAG        Backup docker image tag                                                                   latest
+MYSQL_HOST              MySQL host to target
+MYSQL_USER              MySQL user to perform the backup
+MYSQL_PASSWORD          MySQL user password
+GPG_RECIPIENT           GPG recpient name to be used to encrypt the database archive
+GPG_PUBLIC_KEY          GPG public key content (base64 encoded)
 GPG_TRUST_MODEL         GPG encryption trust model, defaults to "always"                                          always
 ```
 

--- a/mysql/mysql-backup-s3-cronjob-template.yaml
+++ b/mysql/mysql-backup-s3-cronjob-template.yaml
@@ -27,7 +27,7 @@ objects:
             spec:
               containers:
                 - name: mysql-backup-s3-cronjob
-                  image: 'docker.io/rhmap/backups:latest'
+                  image: "${BACKUP_IMAGE}:${BACKUP_IMAGE_TAG}"
                   imagePullPolicy: Always
                   command:
                     - 'bash'
@@ -64,6 +64,12 @@ parameters:
   - name: CRON_SCHEDULE
     description: 'Job schedule in Cron Format [Default is everyday at 2am]'
     value: '0 2 * * *'
+  - name: BACKUP_IMAGE
+    description: 'Backup docker image URL'
+    value: 'docker.io/rhmap/backups'
+  - name: BACKUP_IMAGE_TAG
+    description: 'Backup docker image tag'
+    value: 'latest'
   - name: MYSQL_HOST
     description: 'MySQL host to target'
     required: true

--- a/mysql/mysql-backup-s3-job-template.yaml
+++ b/mysql/mysql-backup-s3-job-template.yaml
@@ -26,7 +26,7 @@ objects:
         spec:
           containers:
             - name: mysql-backup-s3
-              image: 'docker.io/rhmap/backups:latest'
+              image: "${BACKUP_IMAGE}:${BACKUP_IMAGE_TAG}"
               imagePullPolicy: Always
               command:
                 - 'bash'
@@ -60,6 +60,12 @@ parameters:
   - name: AWS_S3_BUCKET_NAME
     description: 'Name of an existing Amazon S3 bucket where backups are to be pushed'
     required: true
+  - name: BACKUP_IMAGE
+    description: 'Backup docker image URL'
+    value: 'docker.io/rhmap/backups'
+  - name: BACKUP_IMAGE_TAG
+    description: 'Backup docker image tag'
+    value: 'latest'
   - name: MYSQL_HOST
     description: 'MySQL host to target'
     required: true


### PR DESCRIPTION
**Summary**
Fixing issue where backups against a replica set do not work when targeting a mongo instance that is not the PRIMARY member of a replica set.

Also exposing the backup docker image URL and tag as parameters for both MongoDB and MySQL templates

**Validation**
Run MongoDB backup job against a primary node in a replicaset using the standard command but with the following additional params specified:
```
-p BACKUP_IMAGE_TAG=1.0.0-824dcf8
```
Now run the same command but change the ```MONGODB_HOST``` param to point at a secondary member of the replica set again with:
```
-p BACKUP_IMAGE_TAG=1.0.0-824dcf8
```
In both cases the backup should run successfully.

Once this change gets merged back we won't need to specify the ```BACKUP_IMAGE_TAG``` param as latest will include these changes.